### PR TITLE
nettest.js: avoid confusing desktop users

### DIFF
--- a/pages/nettest.js
+++ b/pages/nettest.js
@@ -124,7 +124,7 @@ export default class extends React.Component {
           {description && <meta name='og:description' content={description} />}
 
           {/* This is Twitter specific stuff
-            * See: https://dev.twitter.com/cards/types/app */}
+          * See: https://dev.twitter.com/cards/types/app */}
           {deepLink && <meta name='twitter:app:url:iphone' content={deepLink} />}
           {deepLink && <meta name='twitter:app:url:ipad' content={deepLink} />}
           {universalLink && <meta name='twitter:app:url:googleplay' content={universalLink} />}
@@ -140,7 +140,7 @@ export default class extends React.Component {
           {/* This is Facebook specific stuff
             * See:
             * * https://developers.facebook.com/docs/applinks/add-to-content/
-            * * https://blog.branch.io/how-to-deep-link-on-facebook/ */}
+          * * https://blog.branch.io/how-to-deep-link-on-facebook/ */}
           <meta property='al:android:package' content={mobileApp.googlePlayID} />
           <meta property='al:android:app_name' content={mobileApp.googlePlayName} />
           {deepLink && <meta property='al:android:url' content={deepLink} />}
@@ -151,31 +151,31 @@ export default class extends React.Component {
         </Head>
         <OONIRunHero href={'https://run.ooni.io'} />
         <Container p={4}>
-      
-       <Heading pt={2} h={2}>You already have the OONI Probe mobile app</Heading>
+
+          <Heading pt={2} h={2}>You already have the OONI Probe mobile app</Heading>
           <Text pt={2} pb={3}>
             Tap Run and open this link with your OONI Probe mobile app to start the test.
-        </Text>
-      
-      <Link href={deepLink}>
+          </Text>
+
+          <Link href={deepLink}>
             <Button>
-            Run
+              Run
             </Button>
           </Link>
 
           <Heading pt={4} h={2}>Install the OONI Probe mobile app</Heading>
           <Text pt={2} pb={3}>
-            Currently, OONI Run links only work with the OONI Probe mobile app. 
+            Currently, OONI Run links only work with the OONI Probe mobile app.
           </Text>
 
           <Link href={installLink}>
             <Button>
-            Install
+              Install
             </Button>
           </Link>
 
           <Box mt={5}>
-          <Code>{userAgent}</Code>
+            <Code>{userAgent}</Code>
           </Box>
         </Container>
         {withWindowLocation && <script type='text/javascript' dangerouslySetInnerHTML={{__html: windowScript}} />}

--- a/pages/nettest.js
+++ b/pages/nettest.js
@@ -151,18 +151,10 @@ export default class extends React.Component {
         </Head>
         <OONIRunHero href={'https://run.ooni.io'} />
         <Container p={4}>
-          <Text pt={2}>Measure internet censorship by running OONI Probe.</Text>
 
-          <Heading pt={2} h={2}>You have the app</Heading>
-          <Text pt={2} pb={3}>If you have the OONI Probe app installed, click Run to start the test.</Text>
-
-          <Link href={deepLink}>
-            <Button>Run</Button>
-          </Link>
-
-          <Heading pt={4} h={2}>Get the app</Heading>
+          <Heading pt={4} h={2}>Install the OONI Probe mobile app</Heading>
           <Text pt={2} pb={3}>
-            If you are on a desktop computer, click Install to learn how you can install OONI Probe.
+            Currently, OONI Run links only work with the OONI Probe mobile app. 
           </Text>
 
           <Link href={installLink}>

--- a/pages/nettest.js
+++ b/pages/nettest.js
@@ -151,6 +151,17 @@ export default class extends React.Component {
         </Head>
         <OONIRunHero href={'https://run.ooni.io'} />
         <Container p={4}>
+      
+       <Heading pt={2} h={2}>You already have the OONI Probe mobile app</Heading>
+          <Text pt={2} pb={3}>
+            Tap Run and open this link with your OONI Probe mobile app to start the test.
+        </Text>
+      
+      <Link href={deepLink}>
+            <Button>
+            Run
+            </Button>
+          </Link>
 
           <Heading pt={4} h={2}>Install the OONI Probe mobile app</Heading>
           <Text pt={2} pb={3}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,6 +2592,11 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+esprima@^2.6.0:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -3515,13 +3520,21 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.1, js-yaml@~3.7.0:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
+  integrity sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -5634,10 +5647,10 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0, serialize-javascript@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+serialize-javascript@^1.7.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
 serve-static@1.14.1:
   version "1.14.1"


### PR DESCRIPTION
This OONI Run landing page appears if you access an OONI Run link on desktop or if you don't have the mobile app already installed: https://run.ooni.io/nettest?tn=web_connectivity&ta=%7B%22urls%22%3A%5B%22http%3A%2F%2F%22%5D%7D&mv=1.2.0 

I therefore propose that we delete everything in this page & only include a simple instruction telling the user to install the OONI Probe mobile app in order to proceed with using an OONI Run link.

Closes https://github.com/ooni/ooni.org/issues/551