### PR TITLE
URL Editor Rewrite

### DIFF
--- a/components/URLs.js
+++ b/components/URLs.js
@@ -114,6 +114,10 @@ const URLs = ({ onSubmit }) => {
       <Text fontWeight='lighter'>
         <FormattedMessage id='Notice.Paste' defaultMessage='Note: If you have a long list of URLs to add, you can copy them and paste into one of the boxes below.' />
       </Text>
+        <datalist id="url-prefixes">
+          <option value="https://" />
+          <option value="http://" />
+        </datalist>
         <Flex flexDirection='column' my={3}>
           {controlledFields.map((field, index) => (
             <Controller
@@ -126,6 +130,7 @@ const URLs = ({ onSubmit }) => {
                     value={field.value}
                     icon={<MdDelete />}
                     placeholder='https://'
+                    list='url-prefixes'
                     error={errors?.['urls']?.[index]?.['url']?.message}
                     onKeyPress={onKeyPress}
                     onAction={() => remove(index)}

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -1,9 +1,11 @@
-import { Flex, Box, Button, Heading } from "ooni-components"
-import { useForm, useFieldArray } from "react-hook-form"
+import { useCallback } from "react"
+import { Flex, Box, Button, Heading, InputWithIconButton, Text } from "ooni-components"
+import { useForm, useFieldArray, Controller } from "react-hook-form"
 import { FormattedMessage } from "react-intl"
 import styled from "styled-components"
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as Yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as Yup from 'yup'
+import MdDelete from 'react-icons/lib/md/delete'
 
 const AddURLButton = styled(Button)`
   color: ${props => props.theme.colors.gray5};
@@ -26,6 +28,21 @@ const AddURLButton = styled(Button)`
   }
 `
 
+const StyleFixIconButton = styled.div`
+  & ${Flex} {
+    align-items: center;
+  }
+  & p {
+    margin-top: 8px;
+  }
+  & button:hover:enabled {
+    background-color: transparent;
+  }
+  & button:active:enabled {
+    background-color: transparent;
+  }
+`
+
 // Based on https://github.com/citizenlab/test-lists/blob/fd9620f6402f66f7835a831fdcd0731b449e9c52/scripts/lint-lists.py#L18
 const urlValidityRegex = /^(?:http)s?:\/\/(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\d+)?(?:\/?|[/?]\S+)$/i
 
@@ -43,14 +60,14 @@ const validationSchema = Yup.object().shape({
 });
 
 const URLs = ({ toggleGenerate }) => {
-  const { control, register, formState, watch } = useForm({
+  const { control, formState, watch, trigger } = useForm({
     mode: 'onTouched',
-    defaultValues: { urls: [ { url: 'https://' } ] },
+    defaultValues: { urls: [ { url: '' } ] },
     resolver: yupResolver(validationSchema)
   })
-  const { isDirty, errors } = formState
+  const { isDirty, isValid, errors } = formState
 
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, remove, insert, update } = useFieldArray({
     control, // control props comes from useForm (optional: if you are using FormContext)
     name: "urls", // unique name for your Field Array
   })
@@ -62,26 +79,71 @@ const URLs = ({ toggleGenerate }) => {
     }
   })
 
+  const onKeyPress = useCallback((e) => {
+    if (e.key === 'Enter') {
+      append({ url: '' })
+    }
+  }, [append])
+
+  const handlePaste = useCallback((e, index, onChange) => {
+    // block the usual paste action
+    e.preventDefault()
+
+    const pastedText = e.clipboardData.getData('Text')
+    const newEntries = pastedText.split('\n').map((line, i) => (
+      { url: line }
+    ))
+
+    // Place first pasted entry into event and trigger onChange
+    // This updates the field being pasted into with the first entry
+    e.target.value = newEntries[0].url
+    onChange(e)
+    
+    // Insert fields into the form using the rest of the entries
+    insert(index + 1, newEntries.slice(1))
+
+    // Trigger validation to show any errors in the new entries
+    trigger()
+  }, [append, insert, update])
+
   return (
     <Flex flexDirection='column'>
       <Heading h={2}>
         <FormattedMessage id='Title.URLs' defaultMessage='URLs' />
       </Heading>
+      <Text fontWeight='lighter'>
+        <FormattedMessage id='Notice.Paste' defaultMessage='Note: If you have a long list of URLs to add, you can copy them and paste into one of the boxes below.' />
+      </Text>
       <Flex flexDirection='column' my={3}>
         {controlledFields.map((field, index) => (
-          <Flex key={index} alignItems='center'>
-            <input key={field.id} {...register(`urls.${index}.url`)} />
-            <button onClick={() => remove(index)}>⛔️</button>
-            <Box as='small' color='red'>{ errors?.['urls']?.[index]?.['url']?.message }</Box>
-          </Flex>
+          <Controller
+            render={({ field }) => (
+              // <input {...field} />
+              <StyleFixIconButton key={`url-${index}`} className='input-with-button'>
+                <InputWithIconButton
+                  {...field}
+                  className='url-input'
+                  value={field.value}
+                  icon={<MdDelete />}
+                  placeholder='https://'
+                  error={errors?.['urls']?.[index]?.['url']?.message}
+                  onKeyPress={onKeyPress}
+                  onAction={() => remove(index)}
+                  onPaste={(e) => handlePaste(e, index, field.onChange)}
+                />
+              </StyleFixIconButton>
+            )}
+            name={`urls.${index}.url`}
+            control={control}
+          />
         ))}
       </Flex>
       <Box my={2}>
-        <AddURLButton onClick={() => append({ url: 'https://' })}>
+        <AddURLButton onClick={() => append({ url: '' })}>
           + <FormattedMessage id='Button.AddUrl' defaultMessage='Add URL' />
         </AddURLButton>
       </Box>
-      <Button onClick={toggleGenerate}>
+      <Button onClick={toggleGenerate} disabled={!isValid}>
         <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
       </Button>
     </Flex>

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -143,7 +143,7 @@ const URLs = ({ onSubmit }) => {
             + <FormattedMessage id='Button.AddUrl' defaultMessage='Add URL' />
           </AddURLButton>
         </Box>
-        <Button onClick={handleSubmit(onSubmit)} disabled={!isValid}>
+        <Button onClick={handleSubmit(onSubmit)}>
           <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
         </Button>
     </Flex>

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -59,8 +59,8 @@ const validationSchema = Yup.object().shape({
   )
 });
 
-const URLs = ({ toggleGenerate }) => {
-  const { control, formState, watch, trigger } = useForm({
+const URLs = ({ onSubmit }) => {
+  const { control, formState, watch, trigger, handleSubmit } = useForm({
     mode: 'onTouched',
     defaultValues: { urls: [ { url: '' } ] },
     resolver: yupResolver(validationSchema)
@@ -114,38 +114,40 @@ const URLs = ({ toggleGenerate }) => {
       <Text fontWeight='lighter'>
         <FormattedMessage id='Notice.Paste' defaultMessage='Note: If you have a long list of URLs to add, you can copy them and paste into one of the boxes below.' />
       </Text>
-      <Flex flexDirection='column' my={3}>
-        {controlledFields.map((field, index) => (
-          <Controller
-            render={({ field }) => (
-              // <input {...field} />
-              <StyleFixIconButton key={`url-${index}`} className='input-with-button'>
-                <InputWithIconButton
-                  {...field}
-                  className='url-input'
-                  value={field.value}
-                  icon={<MdDelete />}
-                  placeholder='https://'
-                  error={errors?.['urls']?.[index]?.['url']?.message}
-                  onKeyPress={onKeyPress}
-                  onAction={() => remove(index)}
-                  onPaste={(e) => handlePaste(e, index, field.onChange)}
-                />
-              </StyleFixIconButton>
-            )}
-            name={`urls.${index}.url`}
-            control={control}
-          />
-        ))}
-      </Flex>
-      <Box my={2}>
-        <AddURLButton onClick={() => append({ url: '' })}>
-          + <FormattedMessage id='Button.AddUrl' defaultMessage='Add URL' />
-        </AddURLButton>
-      </Box>
-      <Button onClick={toggleGenerate} disabled={!isValid}>
-        <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
-      </Button>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Flex flexDirection='column' my={3}>
+          {controlledFields.map((field, index) => (
+            <Controller
+              render={({ field }) => (
+                // <input {...field} />
+                <StyleFixIconButton key={`url-${index}`} className='input-with-button'>
+                  <InputWithIconButton
+                    {...field}
+                    className='url-input'
+                    value={field.value}
+                    icon={<MdDelete />}
+                    placeholder='https://'
+                    error={errors?.['urls']?.[index]?.['url']?.message}
+                    onKeyPress={onKeyPress}
+                    onAction={() => remove(index)}
+                    onPaste={(e) => handlePaste(e, index, field.onChange)}
+                  />
+                </StyleFixIconButton>
+              )}
+              name={`urls.${index}.url`}
+              control={control}
+            />
+          ))}
+        </Flex>
+        <Box my={2}>
+          <AddURLButton onClick={() => append({ url: '' })}>
+            + <FormattedMessage id='Button.AddUrl' defaultMessage='Add URL' />
+          </AddURLButton>
+        </Box>
+        <Button type='submit' disabled={!isValid}>
+          <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
+        </Button>
+      </form>
     </Flex>
   )
 }

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -81,7 +81,7 @@ const URLs = ({ onSubmit }) => {
 
   const onKeyPress = useCallback((e) => {
     if (e.key === 'Enter') {
-      append({ url: '' })
+      append({ url: '' }, { shouldFocus: true })
     }
   }, [append])
 
@@ -114,7 +114,6 @@ const URLs = ({ onSubmit }) => {
       <Text fontWeight='lighter'>
         <FormattedMessage id='Notice.Paste' defaultMessage='Note: If you have a long list of URLs to add, you can copy them and paste into one of the boxes below.' />
       </Text>
-      <form onSubmit={handleSubmit(onSubmit)}>
         <Flex flexDirection='column' my={3}>
           {controlledFields.map((field, index) => (
             <Controller
@@ -144,10 +143,9 @@ const URLs = ({ onSubmit }) => {
             + <FormattedMessage id='Button.AddUrl' defaultMessage='Add URL' />
           </AddURLButton>
         </Box>
-        <Button type='submit' disabled={!isValid}>
+        <Button onClick={handleSubmit(onSubmit)} disabled={!isValid}>
           <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
         </Button>
-      </form>
     </Flex>
   )
 }

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -90,9 +90,9 @@ const URLs = ({ onSubmit }) => {
     e.preventDefault()
 
     const pastedText = e.clipboardData.getData('Text')
-    const newEntries = pastedText.split('\n').map((line, i) => (
-      { url: line }
-    ))
+    const newEntries = pastedText.split('\n')
+      .filter(line => String(line).length > 0)
+      .map((line, i) => ({ url: line }))
 
     // Place first pasted entry into event and trigger onChange
     // This updates the field being pasted into with the first entry

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -1,0 +1,91 @@
+import { Flex, Box, Button, Heading } from "ooni-components"
+import { useForm, useFieldArray } from "react-hook-form"
+import { FormattedMessage } from "react-intl"
+import styled from "styled-components"
+import { yupResolver } from '@hookform/resolvers/yup';
+import * as Yup from 'yup';
+
+const AddURLButton = styled(Button)`
+  color: ${props => props.theme.colors.gray5};
+  border-radius: 0;
+  padding: 0;
+  background-color: transparent;
+  border-bottom: 1px solid ${props => props.theme.colors.gray1};
+  text-align: left;
+  text-transform: none;
+
+  &:hover, &:hover:enabled {
+    background-color: transparent;
+    color: ${props => props.theme.colors.gray6};
+    border-bottom: 1px solid ${props => props.theme.colors.gray3};
+  }
+  &:active, &:active:enabled {
+    background-color: transparent;
+    color: ${props => props.theme.colors.gray7};
+    border-bottom: 2px solid ${props => props.theme.colors.gray4};
+  }
+`
+
+// Based on https://github.com/citizenlab/test-lists/blob/fd9620f6402f66f7835a831fdcd0731b449e9c52/scripts/lint-lists.py#L18
+const urlValidityRegex = /^(?:http)s?:\/\/(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\d+)?(?:\/?|[/?]\S+)$/i
+
+const validationSchema = Yup.object().shape({
+  urls: Yup.array().of(
+      Yup.object().shape({
+          url: Yup.string()
+              .required('cannot be empty')
+              .matches(/^http(s?)/, 'should start with "https" or "http"')
+              .matches(urlValidityRegex, 'should be a valid URL format e.g "https://ooni.org/post/"')
+              .matches(/\/$/, 'should end with a slash e.g "https://ooni.org/"')
+      // more validations here
+      })
+  )
+});
+
+const URLs = ({ toggleGenerate }) => {
+  const { control, register, formState, watch } = useForm({
+    mode: 'onTouched',
+    defaultValues: { urls: [ { url: 'https://' } ] },
+    resolver: yupResolver(validationSchema)
+  })
+  const { isDirty, errors } = formState
+
+  const { fields, append, remove } = useFieldArray({
+    control, // control props comes from useForm (optional: if you are using FormContext)
+    name: "urls", // unique name for your Field Array
+  })
+  const watchFieldArray = watch('urls')
+  const controlledFields = fields.map((field, index) => {
+    return {
+      ...field,
+      ...watchFieldArray[index]
+    }
+  })
+
+  return (
+    <Flex flexDirection='column'>
+      <Heading h={2}>
+        <FormattedMessage id='Title.URLs' defaultMessage='URLs' />
+      </Heading>
+      <Flex flexDirection='column' my={3}>
+        {controlledFields.map((field, index) => (
+          <Flex key={index} alignItems='center'>
+            <input key={field.id} {...register(`urls.${index}.url`)} />
+            <button onClick={() => remove(index)}>⛔️</button>
+            <Box as='small' color='red'>{ errors?.['urls']?.[index]?.['url']?.message }</Box>
+          </Flex>
+        ))}
+      </Flex>
+      <Box my={2}>
+        <AddURLButton onClick={() => append({ url: 'https://' })}>
+          + <FormattedMessage id='Button.AddUrl' defaultMessage='Add URL' />
+        </AddURLButton>
+      </Box>
+      <Button onClick={toggleGenerate}>
+        <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
+      </Button>
+    </Flex>
+  )
+}
+
+export default URLs

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "@formatjs/intl-utils": "0.6.1",
+    "@hookform/resolvers": "^2.8.2",
     "babel-plugin-inline-react-svg": "1.1.0",
     "express": "^4.15.4",
     "full-icu": "1.3.0",
@@ -14,10 +15,12 @@
     "ooni-components": "0.2.10",
     "react": "16.8.6",
     "react-dom": "16.8.6",
+    "react-hook-form": "^7.17.5",
     "react-icons": "2.2.7",
     "react-intl": "3.1.12",
     "styled-components": "3.4.10",
-    "useragent": "^2.2.1"
+    "useragent": "^2.2.1",
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,15 +1,6 @@
 import React from 'react'
-import Layout from '../components/Layout'
-
 import styled from 'styled-components'
 import { FormattedMessage, useIntl } from 'react-intl'
-import { getUniversalLink } from '../utils/links'
-
-import MdDelete from 'react-icons/lib/md/delete'
-import GraphicsOctopusModal from '../components/svgs/GraphicsOctopusModal.svg'
-
-import OONIRunHero from '../components/OONIRunHero'
-
 import {
   Heading,
   Text,
@@ -21,10 +12,14 @@ import {
   RadioButton,
   Flex,
   Box,
-  InputWithIconButton,
   Modal,
   TwitterShareButton
 } from 'ooni-components'
+
+import Layout from '../components/Layout'
+import { getUniversalLink } from '../utils/links'
+import GraphicsOctopusModal from '../components/svgs/GraphicsOctopusModal.svg'
+import OONIRunHero from '../components/OONIRunHero'
 
 import {
   censorshipTests,
@@ -34,35 +29,6 @@ import {
   messages as nettestMessages
 } from '../utils/nettest'
 import URLs from '../components/URLs'
-
-const AddURLButton = styled(Button)`
-  color: ${props => props.theme.colors.gray5};
-  border-radius: 0;
-  padding: 0;
-  background-color: transparent;
-  border-bottom: 1px solid ${props => props.theme.colors.gray1};
-  text-align: left;
-  text-transform: none;
-
-  &:hover, &:hover:enabled {
-    background-color: transparent;
-    color: ${props => props.theme.colors.gray6};
-    border-bottom: 1px solid ${props => props.theme.colors.gray3};
-  }
-  &:active, &:active:enabled {
-    background-color: transparent;
-    color: ${props => props.theme.colors.gray7};
-    border-bottom: 2px solid ${props => props.theme.colors.gray4};
-  }
-`
-const StyleFixIconButton = styled.div`
-  & button:hover:enabled {
-    background-color: transparent;
-  }
-  & button:active:enabled {
-    background-color: transparent;
-  }
-`
 
 const TestCategoryHeading = styled(Heading)`
   padding: 10px 0;
@@ -103,111 +69,6 @@ const TestDetailsLabel = ({ id, name, desc, checked, value }) => {
   )
 }
 
-class AddURLsSection extends React.Component {
-
-  constructor(props) {
-    super(props)
-    this.state = {
-      urls: props.urls
-    }
-    this.handleDeleteURL = this.handleDeleteURL.bind(this)
-    this.handleEditURL = this.handleEditURL.bind(this)
-    this.handleKeyPress = this.handleKeyPress.bind(this)
-    this.addURL = this.addURL.bind(this)
-    this.urlRefs = new Map()
-  }
-
-  addURL() {
-    let state = Object.assign({}, this.state)
-    const idx = this.state.urls.length
-    state.urls.push({value: 'https://', error: null, ref: null})
-    this.props.onUpdatedURLs(state.urls)
-    this.setState(state, () => {
-      // This is a ghetto hax, that is a workaround for:
-      // https://github.com/jxnblk/rebass/issues/329
-      const urlInputs = document.getElementsByClassName('url-input')
-      const target = urlInputs[urlInputs.length - 1]
-      target.focus()
-      target.setSelectionRange(8,8)
-    })
-  }
-
-  handleKeyPress (e) {
-    if (e.key === 'Enter') {
-      this.addURL()
-    }
-  }
-
-  handleDeleteURL(idx) {
-    return ((event) => {
-      let state = Object.assign({}, this.state)
-      state.urls = state.urls
-                        .filter((url, jdx) => jdx !== idx)
-                        .map(url => Object.assign({}, url))
-      this.setState(state)
-      this.props.onUpdatedURLs(state.urls)
-    }).bind(this)
-  }
-
-  handleEditURL(idx) {
-    return ((event) => {
-      const value = event.target.value
-      let state = Object.assign({}, this.state)
-      state.urls = state.urls.map(url => Object.assign({}, url))
-      state.error = false
-      let update = value.split(' ').map((line) => {
-        const duplicateSchemeRegex = /^https:\/\/(https?)/
-        const fixedLine = line.replace(duplicateSchemeRegex, (_, p1) => p1)
-        let itm = {'value': fixedLine, 'error': null}
-        if (!line.startsWith('https://') && !line.startsWith('http://')) {
-          itm['error'] = 'URL must start with http:// or https://'
-          state.error = true
-        }
-        return itm
-      })
-      state.urls.splice.apply(state.urls, [idx, 1].concat(update))
-      this.setState(state)
-    })
-  }
-
-  render() {
-    const { onUpdatedURLs } = this.props
-    const { urls } = this.state
-
-    return (
-      <Box pt={4}>
-      <Heading h={2} pb={3}>
-        <FormattedMessage id='Title.URLs' defaultMessage='URLs' />
-      </Heading>
-      <ItalicText>
-        <FormattedMessage id='Notice.Paste' defaultMessage='Note: If you have a long list of URLs to add, you can copy them and paste into one of the boxes below.' />
-      </ItalicText>
-        {urls.length == 0
-        && <div>
-          Click "Add URL" below to add a URL to test
-          </div>
-        }
-        {urls.map((url, idx) => <StyleFixIconButton key={`url-${idx}`} className='input-with-button'>
-          <InputWithIconButton
-                className='url-input'
-                value={url.value}
-                icon={<MdDelete />}
-                error={url.error}
-                onKeyPress={this.handleKeyPress}
-                onBlur={() => onUpdatedURLs(urls)}
-                onChange={this.handleEditURL(idx)}
-                onAction={this.handleDeleteURL(idx)} />
-          </StyleFixIconButton>)}
-        <div>
-          <AddURLButton onClick={this.addURL}>
-          + <FormattedMessage id='Button.AddUrl' defaultMessage='Add URL' />
-          </AddURLButton>
-        </div>
-        </Box>
-      )
-    }
-}
-
 const GraphicsWithGradient = styled(Box)`
   width: 100%;
   height: 100%;
@@ -231,12 +92,6 @@ const GraphicsWithGradient = styled(Box)`
       rgba(142, 219, 248, 0),
       rgba(63, 128, 162, 1)
     );
-  }
-`
-const BrandContainer = styled.div`
-  max-width: 100%;
-  svg {
-    max-width: 100%;
   }
 `
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -160,7 +160,9 @@ class AddURLsSection extends React.Component {
       state.urls = state.urls.map(url => Object.assign({}, url))
       state.error = false
       let update = value.split(' ').map((line) => {
-        let itm = {'value': line, 'error': null}
+        const duplicateSchemeRegex = /^https:\/\/(https?)/
+        const fixedLine = line.replace(duplicateSchemeRegex, (_, p1) => p1)
+        let itm = {'value': fixedLine, 'error': null}
         if (!line.startsWith('https://') && !line.startsWith('http://')) {
           itm['error'] = 'URL must start with http:// or https://'
           state.error = true

--- a/pages/index.js
+++ b/pages/index.js
@@ -255,19 +255,25 @@ export default class extends React.Component {
     super()
     this.state = {
       selectedTest: 'web_connectivity',
-      urls: [
-        {value: 'https://', error: null}
-      ],
+      urls: [],
       error: false,
       generated: false
     }
 
     this.handleChange = this.handleChange.bind(this)
     this.toggleGenerate = this.toggleGenerate.bind(this)
+    this.onSubmitURLs = this.onSubmitURLs.bind(this)
   }
 
   toggleGenerate() {
     this.setState({generated: !this.state.generated});
+  }
+
+  onSubmitURLs({ urls }) {
+    this.setState({
+      urls: urls.map(u => u.url),
+      generated: !this.state.generated
+    })
   }
 
   handleChange(stateName) {
@@ -280,7 +286,7 @@ export default class extends React.Component {
   }
 
   render() {
-    const universalLink = getUniversalLink(this.state.selectedTest, this.state.urls.map(u => u.value))
+    const universalLink = getUniversalLink(this.state.selectedTest, [...this.state.urls])
     const embedCode = `
 
     /* For a simple button */
@@ -299,7 +305,6 @@ export default class extends React.Component {
 
         <Container pt={4} maxWidth={800}>
           <Flex flexWrap='wrap'>
-
           <Box width={[1, 1/2]} pb={3}>
           <Heading h={2}>
             <FormattedMessage id='Home.Heading.TestName' defaultMessage='Test Name' />
@@ -334,18 +339,16 @@ export default class extends React.Component {
             <Heading h={2}><FormattedMessage id='Title.WhatCanYouDo' defaultMessage='What you can do' /></Heading>
             <WhatCanYouDoText test={this.state.selectedTest} />
 
-            {this.state.selectedTest == 'web_connectivity'
-            && <URLs toggleGenerate={this.toggleGenerate} />}
-            {/*
-              <AddURLsSection urls={this.state.urls} onUpdatedURLs={this.handleChange('urls')} />}
-            <Box pt={3} pb={3}>
-              <Button onClick={this.toggleGenerate}>
-                <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
-              </Button>
-            </Box> */
-            }
+            {this.state.selectedTest == 'web_connectivity' ? (
+              <URLs onSubmit={this.onSubmitURLs} />
+            ) : (
+              <Box pt={3} pb={3}>
+                <Button onClick={this.toggleGenerate}>
+                  <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
+                </Button>
+              </Box>
+            )}
           </Box>
-
           </Flex>
 
           <Modal

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,6 +33,7 @@ import {
   WhatCanYouDoText,
   messages as nettestMessages
 } from '../utils/nettest'
+import URLs from '../components/URLs'
 
 const AddURLButton = styled(Button)`
   color: ${props => props.theme.colors.gray5};
@@ -334,13 +335,15 @@ export default class extends React.Component {
             <WhatCanYouDoText test={this.state.selectedTest} />
 
             {this.state.selectedTest == 'web_connectivity'
-            && <AddURLsSection urls={this.state.urls} onUpdatedURLs={this.handleChange('urls')} />}
+            && <URLs toggleGenerate={this.toggleGenerate} />}
+            {/*
+              <AddURLsSection urls={this.state.urls} onUpdatedURLs={this.handleChange('urls')} />}
             <Box pt={3} pb={3}>
               <Button onClick={this.toggleGenerate}>
                 <FormattedMessage id='Button.Generate' defaultMessage='Generate' />
               </Button>
-            </Box>
-
+            </Box> */
+            }
           </Box>
 
           </Flex>

--- a/pages/index.js
+++ b/pages/index.js
@@ -124,7 +124,7 @@ class AddURLsSection extends React.Component {
   addURL() {
     let state = Object.assign({}, this.state)
     const idx = this.state.urls.length
-    state.urls.push({value: 'http://', error: null, ref: null})
+    state.urls.push({value: 'https://', error: null, ref: null})
     this.props.onUpdatedURLs(state.urls)
     this.setState(state, () => {
       // This is a ghetto hax, that is a workaround for:
@@ -132,7 +132,7 @@ class AddURLsSection extends React.Component {
       const urlInputs = document.getElementsByClassName('url-input')
       const target = urlInputs[urlInputs.length - 1]
       target.focus()
-      target.setSelectionRange(7,7)
+      target.setSelectionRange(8,8)
     })
   }
 
@@ -255,7 +255,7 @@ export default class extends React.Component {
     this.state = {
       selectedTest: 'web_connectivity',
       urls: [
-        {value: 'http://', error: null}
+        {value: 'https://', error: null}
       ],
       error: false,
       generated: false

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,19 +14,14 @@ import {
   Heading,
   Text,
   Container,
-  Label,
   Input,
   Button,
-  Row,
-  Column,
   Link,
-  Pre,
   RadioGroup,
   RadioButton,
   Flex,
   Box,
   InputWithIconButton,
-  IconButton,
   Modal,
   TwitterShareButton
 } from 'ooni-components'
@@ -183,6 +178,9 @@ class AddURLsSection extends React.Component {
       <Heading h={2} pb={3}>
         <FormattedMessage id='Title.URLs' defaultMessage='URLs' />
       </Heading>
+      <ItalicText>
+        <FormattedMessage id='Notice.Paste' defaultMessage='Note: If you have a long list of URLs to add, you can copy them and paste into one of the boxes below.' />
+      </ItalicText>
         {urls.length == 0
         && <div>
           Click "Add URL" below to add a URL to test

--- a/yarn.lock
+++ b/yarn.lock
@@ -1805,6 +1805,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
@@ -1975,6 +1982,11 @@
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz#2dc8c57044de0340eb53a7ba602e59abf80dc799"
   integrity sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==
 
+"@hookform/resolvers@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.8.2.tgz#590dcc23212a659bad08212138261c3950ef09f1"
+  integrity sha512-oDTGrm7yHxT4VIv4kJcfjvWvozCbdcL0/jrpbAkeo39FYn78XnKOrrGTNmrXdfu+EQVkNIdZ47IYRFManZ4jUA==
+
 "@next/polyfill-nomodule@9.3.2":
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/@next/polyfill-nomodule/-/polyfill-nomodule-9.3.2.tgz#f8e282fdeb448eb6b70bcc18c5d46c911072687a"
@@ -2062,6 +2074,11 @@
   version "4.14.167"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
   integrity sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw==
+
+"@types/lodash@^4.14.175":
+  version "4.14.176"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
+  integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
 
 "@types/node@*":
   version "14.14.20"
@@ -5478,6 +5495,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -5552,6 +5574,11 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -5914,6 +5941,11 @@ nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -7084,6 +7116,11 @@ prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, 
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+property-expr@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
+  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
+
 proxy-addr@~2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
@@ -7255,6 +7292,11 @@ react-error-overlay@5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
+
+react-hook-form@^7.17.5:
+  version "7.17.5"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.17.5.tgz#3852f294159378d0b5893c9fcc89e313937c6f89"
+  integrity sha512-4bPtPGkpVhZlgtTbtMGi0RFphKHgxCj5u3AsGz3SBdleELlG1pDf9zRQOtfGlOGkZlc7u78RzD0xu9kOw7PYdQ==
 
 react-icon-base@2.1.0:
   version "2.1.0"
@@ -8330,6 +8372,11 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 traverse@0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
@@ -8803,3 +8850,16 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yup@^0.32.11:
+  version "0.32.11"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
+  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/lodash" "^4.14.175"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"


### PR DESCRIPTION
This is a rewrite of the URL editor using [`react-hook-form`](react-hook-form.com/).

FIxes #60 
Fixes #62 

* No performance issues even with large number of URLs 
* Improved validation and error messages
* Provides a handy drop down to choose a prefix `https://` or `http://`
<img width="451" alt="image" src="https://user-images.githubusercontent.com/700829/140808307-e06295cb-aceb-45e4-b753-b453a123e83e.png">

