### PR TITLE
fix: a URL is valid if the URL parser says so

### DIFF
--- a/components/URLs.js
+++ b/components/URLs.js
@@ -53,7 +53,7 @@ const validationSchema = Yup.object().shape({
                 'should be a valid URL format e.g "https://ooni.org/post/"',
                 (value) => {
                   try {
-                    let url = new URL(value)
+                    const url = new URL(value)
                     if (url.protocol != "http:" && url.protocol != "https:") {
                       return false
                     }

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -43,17 +43,24 @@ const StyleFixIconButton = styled.div`
   }
 `
 
-// Based on https://github.com/citizenlab/test-lists/blob/fd9620f6402f66f7835a831fdcd0731b449e9c52/scripts/lint-lists.py#L18
-const urlValidityRegex = /^(?:http)s?:\/\/(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\d+)?(?:\/?|[/?]\S+)$/i
-
 const validationSchema = Yup.object().shape({
   urls: Yup.array().of(
       Yup.object().shape({
           url: Yup.string()
               .required('cannot be empty')
               .matches(/^http(s?)/, 'should start with "https" or "http"')
-              .matches(urlValidityRegex, 'should be a valid URL format e.g "https://ooni.org/post/"')
-              .matches(/\/$/, 'should end with a slash e.g "https://ooni.org/"')
+              .test(
+                'is-valid-url',
+                'should be a valid URL format e.g "https://ooni.org/post/"',
+                (value) => {
+                  try {
+                    new URL(value)
+                    return true
+                  } catch {
+                    return false
+                  }
+                }
+              )
       // more validations here
       })
   )

--- a/components/URLs.js
+++ b/components/URLs.js
@@ -48,20 +48,21 @@ const validationSchema = Yup.object().shape({
       Yup.object().shape({
           url: Yup.string()
               .required('cannot be empty')
-              .matches(/^http(s?)/, 'should start with "https" or "http"')
               .test(
                 'is-valid-url',
                 'should be a valid URL format e.g "https://ooni.org/post/"',
                 (value) => {
                   try {
-                    new URL(value)
+                    let url = new URL(value)
+                    if (url.protocol != "http:" && url.protocol != "https:") {
+                      return false
+                    }
                     return true
                   } catch {
                     return false
                   }
                 }
               )
-      // more validations here
       })
   )
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@hookform/resolvers": "^2.8.2",
     "babel-plugin-inline-react-svg": "1.1.0",
     "express": "^4.15.4",
-    "full-icu": "1.3.0",
+    "full-icu": "1.4.0",
     "intl": "1.2.5",
     "intl-locales-supported": "1.8.4",
     "next": "9.3.2",

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,7 +66,9 @@ const Home = () => {
   const [showModal, setShowModal] = useState(false)
 
   const onSubmitURLs = useCallback(({ urls }) => {
-    setUrls([...urls])
+    setUrls(urls.map((url) => {
+      return {"url": new URL(url.url).toString()}
+    }))
     setShowModal(true)
   }, [])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,6 +2979,11 @@ browserslist@^4.14.5, browserslist@^4.16.0:
     escalade "^3.1.1"
     node-releases "^1.1.69"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -4353,6 +4358,13 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -4568,10 +4580,12 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-full-icu@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.0.tgz#1fb4d60050103ad9dcf53735c000e4a03d80c574"
-  integrity sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==
+full-icu@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.4.0.tgz#c387825e3872b39a35b7f3d957650726d00d6b7f"
+  integrity sha512-pH8z7WVKJ3QR/8UoIOZupjRCYqpMFSxjPruYbPS8Ra19UGHuUEsnXP8+ny8o7KCF/AZcEkzJXAtGsveYbP17Uw==
+  dependencies:
+    yauzl "^2.10.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -5570,12 +5584,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.17.21:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -6575,6 +6584,11 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
@@ -8845,6 +8859,14 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yup@^0.32.11:
   version "0.32.11"


### PR DESCRIPTION
Community members have reported issues in pasting into ooni/run
URLs that link to /robots.txt of webpages.

The general ideal of fetching /robots.txt is that you can safely
investigate blocking in a lightweight way, so I think it is quite
important to enable this use case.

Why is validation broken?

It seems we're parsing URLs using a regexp and we're also adding
additional constraints such as "the URL must terminate with /".

Parsing URLs with a regexp, however, is prone to the fact that a
regexp may never be as good as a reason URL parser. So, let us
just use a URL parser to tell us whether a string is an URL.

The "URL must terminate with /" probably comes from the desire to
require a complete URL (i.e., one that has a path set to something
as opposed to a URL that has no path).

However, this rule prevents users for testing for, say, `/robots.txt`
which is not optimal, so I have removed this rule.

While there, I needed to bump full-icu's version number to properly
compile and test this product on my Fedora system. The bump is
from 1.3.0 to 1.4.0, so, if semantic versioning is correctly used,
I think it's an acceptable change to apply.