### PR TITLE
doc: add pull-request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Checklist
+
+- [ ] reference issue for this pull request: <!-- add URL here -->
+
+<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->
+
+## What kind of change does this PR introduce?
+
+Please, insert here a more detailed description.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 - [ ] reference issue for this pull request: <!-- add URL here -->
 
-<!-- Reminder: Location of the issue tracker: https://github.com/ooni/probe -->
+<!-- Reminder: Location of the issue tracker: https://github.com/ooni/run -->
 
 ## What kind of change does this PR introduce?
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Added pull request template for the repository

## Description

There is no pull request template for the [ooni/run](https://github.com/ooni/run), and here's why do we need one? 

- good PR should always make things easy for the code reviewer
- quite useful for new comes to open/write a good PR, basically by helping them – what is all required information that a PR should contain
- no need to copy and paste the template every time when opening a PR, like I'm doing now 😛