### PR TITLE
Add assetlinks for play store verification

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,11 @@ app.prepare().then(() => {
     return res.sendFile(path.join(__dirname, 'public', 'static', 'apple-app-site-association'))
   })
 
+  server.get('/.well-known/assetlinks.json', (req, res) => {
+    res.type('application/json')
+    return res.sendFile(path.join(__dirname, 'public', 'static', 'assetlinks.json'))
+  })
+
   server.get('/nettest', (req, res) => {
     let ua = useragent.parse(req.headers['user-agent'])
     if (ua.family === 'Chrome Mobile' && Number(ua.major) >= 25) {

--- a/public/static/assetlinks.json
+++ b/public/static/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "org.openobservatory.ooniprobe",
+      "sha256_cert_fingerprints": [
+        "BF:7D:A8:2A:7C:77:87:EB:67:56:41:48:23:4B:6D:40:F0:EC:66:4B:F2:92:BC:7A:8F:15:47:FE:7F:E7:5E:84"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
This fixes the issue with deep links on more recent versions of android.